### PR TITLE
Add color to new members

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -356,10 +356,12 @@ html {
 .owner {
   color: #866518 !important;
 }
-.dark .member {
+.dark .member,
+.dark .new {
   color: #04B301;
 }
-.member {
+.member,
+.new {
   color: #0E5D10;
 }
 .superchat {


### PR DESCRIPTION
New members' names in HyperChat were previously not colored, which becomes very apparent during members-only chats. 

The tooltip for the badges of new members is `New member` instead of the usual `Member (** months)`, so the resulting class for the author name in HyperChat becomes `new` instead of `member`.