### PR TITLE
Change background color / padding of chat messages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -300,16 +300,11 @@ export default {
 .message {
   transform-origin: 0 100%;
   overflow: hidden;
-  padding: 5px 5px 5px 5px;
+  padding: 6px;
   text-overflow: ellipsis;
-  border-radius: 5px;
-  min-height: calc(1.7em + 10px);
-}
-.message:nth-child(even) {
-  /* background-color: #202020; */
 }
 .message:nth-child(odd) {
-  background-color: #86868682;
+  background-color: #86868621;
 }
 .content {
   overflow-y: scroll;


### PR DESCRIPTION
**Why**
The grey highlighted chat messages are a bit too bright and it doesn't fit in with the color theme of LiveTL. Also text is slightly mis-aligned vertically. The border-radius is also a bit old-school and not fitting with the material design scheme.
Overall the chat looked a little bit ugly, so I just tweaked it a tiny bit.

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/12624925/119754853-f2a2e400-be98-11eb-8e56-e57a31754ae2.png)

After:
![image](https://user-images.githubusercontent.com/12624925/119754861-f6366b00-be98-11eb-9329-c4ce3c7051e9.png)

Light theme:
![image](https://user-images.githubusercontent.com/12624925/119756482-8675af80-be9b-11eb-935c-323702cd5bd9.png)
