### PR TITLE
Fix URLs posted in chat

### DIFF
--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -73,7 +73,19 @@ const messageReceiveCallback = async (response) => {
         const runs = [];
         if (messageItem.message) {
           messageItem.message.runs.forEach((run) => {
-            if (run.text) {
+            if (run.text && run.navigationEndpoint) {
+              let url = run.navigationEndpoint.commandMetadata.webCommandMetadata.url;
+              if (url.startsWith('/')) {
+                url = 'https://www.youtube.com'.concat(url);
+              }
+              runs.push({
+                type: 'link',
+                text: decodeURIComponent(escape(unescape(encodeURIComponent(
+                  run.text
+                )))),
+                url: url
+              });
+            } else if (run.text) {
               runs.push({
                 type: 'text',
                 text: decodeURIComponent(escape(unescape(encodeURIComponent(

--- a/src/App.vue
+++ b/src/App.vue
@@ -91,6 +91,7 @@
           </strong>
           <span v-for="(run, key, index) in message.info.message" :key="index">
             <span v-if="run.type == 'text'">{{ run.text }}</span>
+            <a v-else-if="run.type == 'link'" :href="run.url" target="_blank">{{ run.text }}</a>
             <img
               v-else-if="run.type == 'emote' && run.src"
               :src="run.src"


### PR DESCRIPTION
URLs posted in chat were previously not handled and the URL text was truncated by YTC, making them pretty much unusable in HyperChat/LiveTL.

This PR fixes this issue, and truncated URLs are correctly hyperlinked (same behavior as YTC).

Before:
![image](https://user-images.githubusercontent.com/20059164/119990203-a40d5b00-bffa-11eb-87ff-c4f8bf5b6922.png)

After:
![image](https://user-images.githubusercontent.com/20059164/119990284-bab3b200-bffa-11eb-85d8-65890ea0f42d.png)

Example streams with URLs posted in chat:
https://youtu.be/MC6yl3CyePA?t=3800
https://youtu.be/yRgjhtHsvNA?t=2880