### PR TITLE
Add support for message deletion events

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -187,7 +187,7 @@ export default {
       } else if (d['yt-live-chat-set-dark-theme'] != null) {
         this.$vuetify.theme.dark = d['yt-live-chat-set-dark-theme'];
         localStorage.setItem('dark_theme', this.$vuetify.theme.dark.toString());
-      } else if (d.type === 'messageChunk') {
+      } else if (d.type === 'actionChunk') {
         if (!d.isReplay && !this.interval) {
           const runQueue = () => {
             this.videoProgressUpdated({
@@ -198,7 +198,10 @@ export default {
           runQueue();
           runQueue();
         }
-        for (const message of d.messages.sort(
+        const messages = d.actions
+          .filter((action) => action.type === 'addChatItem')
+          .map((action) => action.item);
+        for (const message of messages.sort(
           (m1, m2) => m1.showtime - m2.showtime
         )) {
           let timestamp = (Date.now() + message.showtime) / 1000;


### PR DESCRIPTION
The YTC JSON includes `markChatItemsByAuthorAsDeletedAction` and `markChatItemAsDeletedAction` actions when a message author is bonked, and when a message is removed respectively.

This PR adds support for these actions, replacing the message text with what is provided from the JSON and styling it properly.

I've also done some refactors in order to add this feature, and perhaps make it easier to support other actions from the JSON in the future if needed. Here's a summary of the refactors:
- Parsing `addChatItemAction` objects is refactored to `parseAddChatItemAction(action)`.
- Parsing message `runs` objects is refactored to `parseMessageRuns(runs)`.
- Renamed `messageChunk` to `actionChunk` for clarity. The `messages` property is also renamed to `actions`.
- Instead of an array of message objects in `messageChunk`, `actionChunk` is an array of action objects, consisting of `type` and `item`. Message objects are now in the `item` property of `type: 'addChatItem'` actions.

My testing hasn't shown any problems regarding the changes, but I would suggest adding it to a LiveTL beta before pushing to public in case there's some bug I missed.

Example Images:
| Dark mode | Lite mode|
|---|---|
| ![image](https://user-images.githubusercontent.com/20059164/120161899-698a0500-c22a-11eb-9cc5-d17dfa59e9ae.png) | ![image](https://user-images.githubusercontent.com/20059164/120161926-727ad680-c22a-11eb-9309-875d03fc9b87.png) |
| ![image](https://user-images.githubusercontent.com/20059164/120162380-e5844d00-c22a-11eb-9e5a-635069b46ace.png) | ![image](https://user-images.githubusercontent.com/20059164/120162416-f03ee200-c22a-11eb-9859-5c580ef7202b.png) |