### PR TITLE
Fix autoscroll during message deletion

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -228,9 +228,13 @@ export default {
         if (!bonks.length && !deletions.length) {
           return;
         }
+        const wasBottom = this.checkIfBottom();
         this.messages.forEach((message) =>
           this.checkDeleted(message, bonks, deletions)
         );
+        if (wasBottom) {
+          this.$nextTick(this.scrollToBottom);
+        }
       }
     });
     window.parent.postMessage(

--- a/src/changelog.js
+++ b/src/changelog.js
@@ -36,9 +36,9 @@ exports.updates = [
   },
   {
     version: 'v1.1.0',
-    comments: 'Launch button overhaul, support for [message deleted], clickable links, and more!' +
-              'We hope support for deleted messages can cut down on spam' +
-              'about the news of Coco\'s graduation. Please remember to respect stream' +
+    comments: 'Launch button overhaul, support for [message deleted], clickable links, and more! ' +
+              'We hope support for deleted messages can cut down on spam ' +
+              'about the news of Coco\'s graduation. Please remember to respect stream ' +
               'chat etiquette in other streamers\' chats.'
   }
 ];


### PR DESCRIPTION
When messages already shown in chat are deleted, the autoscroll may sometimes stop, causing further messages to stop loading as well. 

This commit makes chat scroll to the bottom whenever message deletions are processed to prevent this issue.