### PR TITLE
Add initial data support

### DIFF
--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -660,5 +660,8 @@ const chatLoaded = async () => {
   }
 };
 
-window.addEventListener('load', chatLoaded);
-if (document.readyState === 'complete') chatLoaded();
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', chatLoaded);
+} else {
+  chatLoaded();
+}

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -149,13 +149,13 @@ const messageReceiveCallback = async (response, isInitial = false) => {
   response = JSON.parse(response);
   try {
     const actions = [];
-    if (!response.continuationContents) {
+    const actionsObject = response?.continuationContents?.liveChatContinuation?.actions ||
+      response?.contents?.liveChatRenderer?.actions;
+    if (!actionsObject) {
       console.debug('Response was invalid', response);
       return;
     }
-    (
-      response.continuationContents.liveChatContinuation.actions || []
-    ).forEach((action) => {
+    (actionsObject || []).forEach((action) => {
       try {
         let parsedAction;
         if (action.addChatItemAction) {
@@ -653,11 +653,7 @@ const chatLoaded = async () => {
     });
   };
   const iframe = document.querySelector('#optichat');
-  if (iframe.readyState === 'complete') {
-    processInitialJson();
-  } else {
-    iframe.addEventListener('load', processInitialJson);
-  }
+  iframe.addEventListener('load', processInitialJson);
 };
 
 if (document.readyState === 'loading') {

--- a/src/App.vue
+++ b/src/App.vue
@@ -218,7 +218,7 @@ export default {
           (m1, m2) => m1.showtime - m2.showtime
         )) {
           let timestamp = (Date.now() + message.showtime) / 1000;
-          if (d.isReplay) timestamp = message.showtime;
+          if (d.isReplay || d.isInitial) timestamp = message.showtime;
           this.checkDeleted(message, bonks, deletions);
           this.queued.push({
             timestamp,


### PR DESCRIPTION
This PR adds support for the initial chat data available in the body of the chat iframe. This opens up opportunities to properly support stuff like pinned messages, the SC/member "ticker bar" etc in the future if needed.

Since the initial chat messages will be shown almost immediately, this does sort of make the welcome message with the changelog unviewable, as the initial messages will immediately push it to the top of the chat. This was already a problem for VOD chat replays before this, and I'm not quite sure how to elegantly fix this (or if a fix is needed), so I'm open for discussion/suggestions.

I've also changed HC to load at or after `DOMContentLoaded` instead of on `load`, which should theoretically speed up initial load times since it no longer has to wait for stuff like profile pictures to finish loading. 