### PR TITLE
Workaround for script running twice

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
   env: {
-    node: true
+    node: true,
+    webextensions: true
   },
   extends: [
     'plugin:vue/essential',


### PR DESCRIPTION
A workaround for LiveTL/HyperChat#12, the script will now check whether `chrome.windows` is accessible before continuing. Context scripts shouldn't be able to access `chrome.windows`, but wherever the plugin is running scripts a second time, they have access to it.

I've also gone ahead and remove the pollers, legacy checks for Android and move the huge `if (hyperChatEnabled)` block into a guard clause.

I don't think this should be a permanent solution though, moving off of the plugin for standalone HC would be best.