### PR TITLE
[WIP] Add support for pinned messages

### DIFF
--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -199,6 +199,8 @@ const messageReceiveCallback = async (response, isInitial = false) => {
           parsedAction = parsePinnedMessageAction(
             action.addBannerToLiveChatCommand
           );
+        } else if (action.removeBannerForLiveChatCommand) {
+          parsedAction = { type: 'removePinned' };
         }
         if (!parsedAction) {
           return;


### PR DESCRIPTION
I've added the JSON parsing for pinned messages, but I'm clueless on the Vue UI side so I'll need someone else's help on that department.

The parsed object will be sent thru `actionChunk` as per usual, and its properties are as follows:
| Property | Description |
| --- | --- |
| `type` | `messagePinned` |
| `header` | A parsed runs array. It's usually just text such as "Pinned by [channel owner]". |
| `contents` | The message object itself. It has the same properties as the usual `addChatItem` object. |

One thing to note is that I implemented the parsing based on initial data JSON. I'm assuming it'll be the same for live pins while the chat is already running, but without a live test I wouldn't be able to confirm.

I believe there's also an "unpin" action for when the channel owner unpins a message, which would also need a live test to figure out.