### PR TITLE
checkDeleted skips welcomeMessage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -321,6 +321,7 @@ export default {
       }
     },
     checkDeleted(message, bonks, deletions) {
+      if (message.welcomeMessage) return;
       for (const bonk of bonks) {
         if (bonk.authorId === message.author.id) {
           message.message = bonk.replacedMessage;


### PR DESCRIPTION
When there are bonks or deletions in the initial data, `welcomeMessage` will cause TypeError during `checkDeleted` as it does not have an author property. This is probably what's been causing HyperChat to randomly fail to load as some people have reported in the discord.