### PR TITLE
Major interceptor refactor (chat)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   root: true,
   env: {
-    node: true
+    node: true,
+    webextensions: true
   },
   extends: [
     'plugin:vue/essential',

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -56,7 +56,7 @@ const getPortFrameInfo = (port) => {
     tabId: port.sender.tab.id,
     frameId: port.sender.frameId
   };
-}
+};
 
 /**
  * @param {Port} port
@@ -220,8 +220,8 @@ const setInitialData = (senderPort, message) => {
 };
 
 /**
- * @param {Port} senderPort 
- * @param {number} playerProgress 
+ * @param {Port} senderPort
+ * @param {number} playerProgress
  */
 const sendPlayerProgress = (senderPort, playerProgress) => {
   const frameInfo = getPortFrameInfo(senderPort);

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -1,4 +1,5 @@
-/* eslint-disable no-undef */
+const isLiveTL = false;
+// DO NOT EDIT THE ABOVE LINE. It is updated by webpack.
 /** @typedef {{onMessage, postMessage, onDisconnect, sender?, name?}} Port */
 /** @typedef {{frameInfo: FrameInfo, port: Port, clients: Port[]}} Interceptor */
 
@@ -26,6 +27,14 @@ class FrameInfo {
   }
 }
 
+chrome.browserAction.onClicked.addListener(() => {
+  if (isLiveTL) {
+    chrome.tabs.create({ url: 'https://livetl.app' });
+  } else {
+    chrome.tabs.create({ url: chrome.runtime.getURL('index.html#/review') });
+  }
+});
+
 // const sendMessageAsync = (data) => {
 //   // eslint-disable-next-line no-unused-vars
 //   return new Promise((resolve, reject) => chrome.runtime.sendMessage(data, resolve));
@@ -49,7 +58,7 @@ class FrameInfo {
 const queryFrameInfo = (port) => {
   const sender = port.sender;
   if (!sender) {
-    console.debug('Port has no sender', { port });
+    console.debug('Port has no sender, query failed', { port });
     return;
   }
 
@@ -67,7 +76,7 @@ const queryFrameInfo = (port) => {
  */
 const registerInterceptor = (port) => {
   if (!port.sender) {
-    console.debug('Interceptor port has no sender', { port });
+    console.debug('Interceptor port has no sender, not registering', { port });
     return;
   }
   const tabId = port.sender.tab.id;
@@ -77,7 +86,7 @@ const registerInterceptor = (port) => {
   if (interceptors.some(
     (interceptor) => interceptor.frameInfo.compare(frameInfo)
   )) {
-    console.debug('Interceptor already registered', { port, interceptors });
+    console.debug('Interceptor already registered, not registering', { port, interceptors });
     return;
   }
 
@@ -152,7 +161,10 @@ const registerClient = (port, frameInfo) => {
  */
 const sendToClients = (senderPort, frameInfo, payload) => {
   if (!frameInfo || !payload) {
-    console.debug('Invalid message', { senderPort, frameInfo, payload });
+    console.debug(
+      'Invalid message, not sending to clients',
+      { senderPort, frameInfo, payload }
+    );
     return;
   }
 
@@ -168,13 +180,8 @@ const sendToClients = (senderPort, frameInfo, payload) => {
 
   if (!sent) {
     console.debug(
-      'Interceptor not registered',
-      {
-        interceptors,
-        senderPort,
-        frameInfo,
-        payload
-      }
+      'Interceptor not registered, no clients to send to',
+      { interceptors, senderPort, frameInfo, payload }
     );
   }
 };

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -186,6 +186,7 @@ const sendToClients = (senderPort, frameInfo, payload) => {
   }
 };
 
+/** Start background messaging */
 chrome.runtime.onConnect.addListener((port) => {
   port.onMessage.addListener((message) => {
     if (!message.type) {

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -31,7 +31,6 @@ const cleanupInterceptor = (i) => {
   }
 };
 
-// FIXME: Embed TLs doesn't unregister first interceptor
 /**
  * Register a new interceptor.
  * Will immediately respond with its FrameInfo on success.
@@ -93,6 +92,14 @@ const registerClient = (port, frameInfo, getInitialData) => {
   if (!interceptor) {
     console.debug(
       'Failed to find interceptor, register client unsuccessful',
+      { interceptors, port, frameInfo }
+    );
+    return;
+  }
+
+  if (interceptor.clients.some((client) => client.name === port.name)) {
+    console.debug(
+      'Client already registered. Not registering',
       { interceptors, port, frameInfo }
     );
     return;

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -19,7 +19,6 @@ const compareFrameInfo = (a, b) => {
 
 /**
  * If port and clients are empty, removes interceptor from array.
- *
  * @param {number} i Index of interceptor
  */
 const cleanupInterceptor = (i) => {
@@ -33,7 +32,6 @@ const cleanupInterceptor = (i) => {
 /**
  * Register a new interceptor.
  * Will immediately respond with its FrameInfo on success.
- *
  * @param {Port} port
  */
 const registerInterceptor = (port) => {
@@ -81,8 +79,6 @@ const registerInterceptor = (port) => {
 };
 
 /**
- * Register a new client to an interceptor.
- *
  * @param {Port} port
  * @param {FrameInfo} frameInfo
  * @param {boolean} [getInitialData]
@@ -126,11 +122,9 @@ const registerClient = (port, frameInfo, getInitialData) => {
 };
 
 /**
- * Send payload to clients of interceptors with matching frameInfo
- *
  * @param {Port} senderPort
  * @param {FrameInfo} frameInfo
- * @param {any} payload
+ * @param {*} payload
  */
 const sendToClients = (senderPort, frameInfo, payload) => {
   if (!payload) {
@@ -160,6 +154,11 @@ const sendToClients = (senderPort, frameInfo, payload) => {
   console.debug('Sent to clients', { interceptor, payload });
 };
 
+/**
+ * @param {Port} senderPort
+ * @param {FrameInfo} frameInfo
+ * @param {*} payload
+ */
 const setInitialData = (senderPort, frameInfo, payload) => {
   if (!payload) {
     console.debug(
@@ -237,7 +236,3 @@ if (!(window.location.href.includes(`${chrome.runtime.id}/index.html`))) {
     }
   });
 }
-
-// Interceptor register - save frameInfo
-// Client register with matching frameInfo - save as clients of matching interceptor
-// Interceptor send response object - send to all clients

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -37,38 +37,37 @@ class FrameInfo {
 
 // chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 //   if (request.type === 'getFrameInfo') {
-//     sendResponse({
-//       tabId: sender.tab.id,
-//       frameId: sender.frameId
-//     });
+//     sendResponse(new FrameInfo(sender.tab.id, sender.frameId));
 //   }
 // });
 
 /**
  * Respond with sender's frame info.
+ *
  * @param {Port} port
  */
 const queryFrameInfo = (port) => {
   const sender = port.sender;
   if (!sender) {
-    console.debug('Port has no sender', port);
+    console.debug('Port has no sender', { port });
     return;
   }
 
-  port.postMessage({
-    type: 'queryResult',
-    frameInfo: new FrameInfo(port.sender.tab.id, port.sender.frameId)
-  });
+  const frameInfo = new FrameInfo(port.sender.tab.id, port.sender.frameId);
+
+  port.postMessage({ type: 'queryResult', frameInfo });
+  console.debug('Query successful', { port, frameInfo });
 };
 
 /**
  * Register a new interceptor.
  * Will immediately respond with its FrameInfo on success.
+ *
  * @param {Port} port
  */
 const registerInterceptor = (port) => {
   if (!port.sender) {
-    console.debug('Interceptor port has no sender', port);
+    console.debug('Interceptor port has no sender', { port });
     return;
   }
   const tabId = port.sender.tab.id;
@@ -78,7 +77,7 @@ const registerInterceptor = (port) => {
   if (interceptors.some(
     (interceptor) => interceptor.frameInfo.compare(frameInfo)
   )) {
-    console.debug('Interceptor already registered', port, interceptors);
+    console.debug('Interceptor already registered', { port, interceptors });
     return;
   }
 
@@ -88,27 +87,30 @@ const registerInterceptor = (port) => {
       (interceptor) => interceptor.frameInfo.compare(frameInfo)
     );
     if (i < 0) {
-      console.debug('Failed to unregister interceptor', port, interceptors);
+      console.debug('Failed to unregister interceptor', { port, interceptors });
       return;
     }
     interceptors.splice(i, 1);
+    console.debug('Unregister intercepter successful', { port, interceptors });
   });
 
   interceptors.push({ frameInfo: frameInfo, port: port, clients: [] });
-  port.postMessage({ type: 'registered', frameInfo: frameInfo });
+  port.postMessage({ type: 'interceptorRegistered', frameInfo: frameInfo });
+  console.debug('Register interceptor successful', { frameInfo });
 };
 
 /**
  * Register a new client to an interceptor.
  * Client port MUST have a name.
+ *
  * @param {Port} port
  * @param {FrameInfo} frameInfo
  */
 const registerClient = (port, frameInfo) => {
   if (!port.name || port.name === '') {
-    // port.name = `${Date.now()}${Math.random()}`;
-    console.debug('Client port does not have a name', port, frameInfo);
-    return;
+    port.name = `${Date.now()}${Math.random()}`;
+    console.debug('Gave client port a name', { port, frameInfo });
+    // return;
   }
 
   const registered = interceptors.some((interceptor) => {
@@ -122,30 +124,35 @@ const registerClient = (port, frameInfo) => {
         (clientPort) => clientPort.name === port.name
       );
       if (i < 0) {
-        console.debug('Failed to unregister client', port, interceptor);
+        console.debug('Failed to unregister client', { port, interceptor });
         return;
       }
       interceptor.clients.splice(i, 1);
+      console.debug('Unregister client successful', { port, interceptor });
     });
 
     interceptor.clients.push(port);
+    console.debug('Register client successful', { interceptor, port });
     return true;
   });
 
   if (!registered) {
-    console.debug('Failed to register client', interceptors, port, frameInfo);
+    console.debug(
+      'Failed to register client', { interceptors, port, frameInfo }
+    );
   }
 };
 
 /**
  * Send payload to clients of interceptors with matching frameInfo
+ *
  * @param {Port} senderPort
  * @param {FrameInfo} frameInfo
  * @param {any} payload
  */
 const sendToClients = (senderPort, frameInfo, payload) => {
   if (!frameInfo || !payload) {
-    console.debug('Invalid message', senderPort, frameInfo, payload);
+    console.debug('Invalid message', { senderPort, frameInfo, payload });
     return;
   }
 
@@ -155,16 +162,19 @@ const sendToClients = (senderPort, frameInfo, payload) => {
     }
 
     interceptor.clients.forEach((port) => port.postMessage(payload));
+    console.debug('Sent to clients', { interceptor, payload });
     return true;
   });
 
   if (!sent) {
     console.debug(
       'Interceptor not registered',
-      interceptors,
-      senderPort,
-      frameInfo,
-      payload
+      {
+        interceptors,
+        senderPort,
+        frameInfo,
+        payload
+      }
     );
   }
 };
@@ -184,11 +194,11 @@ chrome.runtime.onConnect.addListener((port) => {
         registerInterceptor(port);
         break;
       case 'registerClient':
-        registerClient(port, new FrameInfo(message.tabId, message.frameId));
+        registerClient(port, message.frameInfo);
         break;
       case 'sendToClients':
         sendToClients(
-          port, new FrameInfo(message.tabId, message.frameId), message.payload
+          port, message.frameInfo, message.payload
         );
         break;
       default:

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -35,21 +35,6 @@ chrome.browserAction.onClicked.addListener(() => {
   }
 });
 
-// const sendMessageAsync = (data) => {
-//   // eslint-disable-next-line no-unused-vars
-//   return new Promise((resolve, reject) => chrome.runtime.sendMessage(data, resolve));
-// };
-
-// export const getFrameInfoAsync = async () => {
-//   return await sendMessageAsync({ type: 'getFrameInfo' });
-// };
-
-// chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-//   if (request.type === 'getFrameInfo') {
-//     sendResponse(new FrameInfo(sender.tab.id, sender.frameId));
-//   }
-// });
-
 /**
  * Respond with sender's frame info.
  *
@@ -171,6 +156,11 @@ const sendToClients = (senderPort, frameInfo, payload) => {
   const sent = interceptors.some((interceptor) => {
     if (!interceptor.frameInfo.compare(frameInfo)) {
       return false;
+    }
+
+    if (interceptor.clients.length < 1) {
+      console.debug('No clients to send to', { interceptor, payload });
+      return true;
     }
 
     interceptor.clients.forEach((port) => port.postMessage(payload));

--- a/scripts/chat-background.js
+++ b/scripts/chat-background.js
@@ -1,0 +1,203 @@
+/* eslint-disable no-undef */
+/** @typedef {{onMessage, postMessage, onDisconnect, sender?, name?}} Port */
+/** @typedef {{frameInfo: FrameInfo, port: Port, clients: Port[]}} Interceptor */
+
+/** @type {Interceptor[]} */
+const interceptors = [];
+
+/** Tab and frame info of an interceptor. */
+class FrameInfo {
+  /**
+   * @param {number} tabId
+   * @param {number} frameId
+   */
+  constructor(tabId, frameId) {
+    this.tabId = tabId;
+    this.frameId = frameId;
+  }
+
+  /**
+   * @param {FrameInfo} frameInfo
+   * @return {boolean} True if frameInfo matches `this`.
+   */
+  compare(frameInfo) {
+    return this.tabId === frameInfo.tabId &&
+      this.frameId === frameInfo.frameId;
+  }
+}
+
+// const sendMessageAsync = (data) => {
+//   // eslint-disable-next-line no-unused-vars
+//   return new Promise((resolve, reject) => chrome.runtime.sendMessage(data, resolve));
+// };
+
+// export const getFrameInfoAsync = async () => {
+//   return await sendMessageAsync({ type: 'getFrameInfo' });
+// };
+
+// chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+//   if (request.type === 'getFrameInfo') {
+//     sendResponse({
+//       tabId: sender.tab.id,
+//       frameId: sender.frameId
+//     });
+//   }
+// });
+
+/**
+ * Respond with sender's frame info.
+ * @param {Port} port
+ */
+const queryFrameInfo = (port) => {
+  const sender = port.sender;
+  if (!sender) {
+    console.debug('Port has no sender', port);
+    return;
+  }
+
+  port.postMessage({
+    type: 'queryResult',
+    frameInfo: new FrameInfo(port.sender.tab.id, port.sender.frameId)
+  });
+};
+
+/**
+ * Register a new interceptor.
+ * Will immediately respond with its FrameInfo on success.
+ * @param {Port} port
+ */
+const registerInterceptor = (port) => {
+  if (!port.sender) {
+    console.debug('Interceptor port has no sender', port);
+    return;
+  }
+  const tabId = port.sender.tab.id;
+  const frameId = port.sender.frameId;
+  const frameInfo = new FrameInfo(tabId, frameId);
+
+  if (interceptors.some(
+    (interceptor) => interceptor.frameInfo.compare(frameInfo)
+  )) {
+    console.debug('Interceptor already registered', port, interceptors);
+    return;
+  }
+
+  // Unregister interceptor when port disconnects
+  port.onDisconnect.addListener(() => {
+    const i = interceptors.findIndex(
+      (interceptor) => interceptor.frameInfo.compare(frameInfo)
+    );
+    if (i < 0) {
+      console.debug('Failed to unregister interceptor', port, interceptors);
+      return;
+    }
+    interceptors.splice(i, 1);
+  });
+
+  interceptors.push({ frameInfo: frameInfo, port: port, clients: [] });
+  port.postMessage({ type: 'registered', frameInfo: frameInfo });
+};
+
+/**
+ * Register a new client to an interceptor.
+ * Client port MUST have a name.
+ * @param {Port} port
+ * @param {FrameInfo} frameInfo
+ */
+const registerClient = (port, frameInfo) => {
+  if (!port.name || port.name === '') {
+    // port.name = `${Date.now()}${Math.random()}`;
+    console.debug('Client port does not have a name', port, frameInfo);
+    return;
+  }
+
+  const registered = interceptors.some((interceptor) => {
+    if (!interceptor.frameInfo.compare(frameInfo)) {
+      return false;
+    }
+
+    // Unregister client when port disconnects
+    port.onDisconnect.addListener(() => {
+      const i = interceptor.clients.findIndex(
+        (clientPort) => clientPort.name === port.name
+      );
+      if (i < 0) {
+        console.debug('Failed to unregister client', port, interceptor);
+        return;
+      }
+      interceptor.clients.splice(i, 1);
+    });
+
+    interceptor.clients.push(port);
+    return true;
+  });
+
+  if (!registered) {
+    console.debug('Failed to register client', interceptors, port, frameInfo);
+  }
+};
+
+/**
+ * Send payload to clients of interceptors with matching frameInfo
+ * @param {Port} senderPort
+ * @param {FrameInfo} frameInfo
+ * @param {any} payload
+ */
+const sendToClients = (senderPort, frameInfo, payload) => {
+  if (!frameInfo || !payload) {
+    console.debug('Invalid message', senderPort, frameInfo, payload);
+    return;
+  }
+
+  const sent = interceptors.some((interceptor) => {
+    if (!interceptor.frameInfo.compare(frameInfo)) {
+      return false;
+    }
+
+    interceptor.clients.forEach((port) => port.postMessage(payload));
+    return true;
+  });
+
+  if (!sent) {
+    console.debug(
+      'Interceptor not registered',
+      interceptors,
+      senderPort,
+      frameInfo,
+      payload
+    );
+  }
+};
+
+chrome.runtime.onConnect.addListener((port) => {
+  port.onMessage.addListener((message) => {
+    if (!message.type) {
+      console.debug('Message has no type', port, message);
+      return;
+    }
+
+    switch (message.type) {
+      case 'queryFrameInfo':
+        queryFrameInfo(port);
+        break;
+      case 'registerInterceptor':
+        registerInterceptor(port);
+        break;
+      case 'registerClient':
+        registerClient(port, new FrameInfo(message.tabId, message.frameId));
+        break;
+      case 'sendToClients':
+        sendToClients(
+          port, new FrameInfo(message.tabId, message.frameId), message.payload
+        );
+        break;
+      default:
+        console.debug('Unknown message type', port, message);
+        break;
+    }
+  });
+});
+
+// Interceptor register - save frameInfo
+// Client register with matching frameInfo - save as clients of matching interceptor
+// Interceptor send response object - send to all clients

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,3 +1,7 @@
+const isReplay = window.location.href.startsWith(
+  'https://www.youtube.com/live_chat_replay'
+);
+
 const chatLoaded = () => {
   /** Workaround for https://github.com/LiveTL/HyperChat/issues/12 */
   if (chrome.windows) return;
@@ -37,7 +41,8 @@ const chatLoaded = () => {
         port.postMessage({
           type: 'sendToClients',
           frameInfo,
-          response: d.detail
+          response: d.detail,
+          isReplay
         });
       });
 
@@ -53,7 +58,8 @@ const chatLoaded = () => {
         port.postMessage({
           type: 'setInitialData',
           frameInfo,
-          response: json
+          response: json,
+          isReplay
         });
         break;
       }

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,0 +1,46 @@
+import { parseChatResponse } from './parse-chat.js';
+
+const connectedPorts = [];
+
+export const messageReceiveCallback = (response, isInitial = false) => {
+  connectedPorts.forEach((port) => {
+    port.postMessage(parseChatResponse(response, isInitial));
+  });
+};
+
+const chatLoaded = () => {
+  const script = document.createElement('script');
+  script.innerHTML = `
+    for (event_name of ["visibilitychange", "webkitvisibilitychange", "blur"]) {
+      window.addEventListener(event_name, event => {
+        event.stopImmediatePropagation();
+      }, true);
+    }
+    window.fetchFallback = window.fetch;
+    window.fetch = async (...args) => {
+      const url = args[0].url;
+      const result = await window.fetchFallback(...args);
+      if (url.startsWith(
+        'https://www.youtube.com/youtubei/v1/live_chat/get_live_chat')
+      ) {
+        const response = JSON.stringify(await (await result.clone()).json());
+        window.dispatchEvent(new CustomEvent('messageReceive', { detail: response }));
+      }
+      return result;
+    };
+  `;
+
+  // eslint-disable-next-line no-undef
+  chrome.runtime.onConnect.addListener((port) => {
+    connectedPorts.push(port);
+  });
+
+  window.addEventListener('messageReceive', d => messageReceiveCallback(d.detail));
+  document.body.appendChild(script);
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', chatLoaded);
+} else {
+  chatLoaded();
+}

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,4 +1,4 @@
-import { parseChatResponse } from './parse-chat.js';
+import { parseChatResponse } from './chat-parser.js';
 
 const connectedPorts = [];
 // eslint-disable-next-line no-undef

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,6 +1,5 @@
 import { parseChatResponse } from './chat-parser.js';
 
-// eslint-disable-next-line no-undef
 const port = chrome.runtime.connect();
 let frameInfo;
 port.onMessage.addListener((message) => {

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,5 +1,3 @@
-import { parseChatResponse } from './chat-parser.js';
-
 const chatLoaded = () => {
   /** Workaround for https://github.com/LiveTL/HyperChat/issues/12 */
   if (chrome.windows) return;
@@ -39,7 +37,7 @@ const chatLoaded = () => {
         port.postMessage({
           type: 'sendToClients',
           frameInfo,
-          payload: parseChatResponse(d.detail)
+          response: d.detail
         });
       });
 
@@ -55,7 +53,7 @@ const chatLoaded = () => {
         port.postMessage({
           type: 'setInitialData',
           frameInfo,
-          payload: parseChatResponse(json, true)
+          response: json
         });
         break;
       }

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,8 +1,12 @@
 import { parseChatResponse } from './parse-chat.js';
 
 const connectedPorts = [];
+// eslint-disable-next-line no-undef
+chrome.runtime.onConnect.addListener((port) => {
+  connectedPorts.push(port);
+});
 
-export const messageReceiveCallback = (response, isInitial = false) => {
+const messageReceiveCallback = (response, isInitial = false) => {
   connectedPorts.forEach((port) => {
     port.postMessage(parseChatResponse(response, isInitial));
   });
@@ -29,11 +33,6 @@ const chatLoaded = () => {
       return result;
     };
   `;
-
-  // eslint-disable-next-line no-undef
-  chrome.runtime.onConnect.addListener((port) => {
-    connectedPorts.push(port);
-  });
 
   window.addEventListener('messageReceive', d => messageReceiveCallback(d.detail));
   document.body.appendChild(script);

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,5 +1,6 @@
 import { parseChatResponse } from './chat-parser.js';
 
+/** Register interceptor */
 const port = chrome.runtime.connect();
 let frameInfo;
 port.onMessage.addListener((message) => {
@@ -10,6 +11,12 @@ port.onMessage.addListener((message) => {
 });
 port.postMessage({ type: 'registerInterceptor' });
 
+/**
+ * Parse and send YTC JSON response.
+ *
+ * @param {*} response YTC JSON response
+ * @param {boolean} [isInitial=false]
+ */
 const messageReceiveCallback = (response, isInitial = false) => {
   port.postMessage({
     type: 'sendToClients',
@@ -18,11 +25,13 @@ const messageReceiveCallback = (response, isInitial = false) => {
   });
 };
 
+// FIXME: VOD chat does not work at the moment.
 const chatLoaded = () => {
+  /** Inject interceptor script */
   const script = document.createElement('script');
   script.innerHTML = `
-    for (event_name of ["visibilitychange", "webkitvisibilitychange", "blur"]) {
-      window.addEventListener(event_name, event => {
+    for (eventName of ["visibilitychange", "webkitvisibilitychange", "blur"]) {
+      window.addEventListener(eventName, event => {
         event.stopImmediatePropagation();
       }, true);
     }
@@ -39,7 +48,6 @@ const chatLoaded = () => {
       return result;
     };
   `;
-
   window.addEventListener('messageReceive', d => messageReceiveCallback(d.detail));
   document.body.appendChild(script);
 
@@ -60,6 +68,10 @@ const chatLoaded = () => {
   // iframe.addEventListener('load', processInitialJson);
 };
 
+/**
+ * Load on DOMContentLoaded or later.
+ * Does not matter unless run_at is specified in extensions' manifest.
+ */
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', chatLoaded);
 } else {

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,6 +1,9 @@
 import { parseChatResponse } from './chat-parser.js';
 
 const chatLoaded = () => {
+  /** Workaround for https://github.com/LiveTL/HyperChat/issues/12 */
+  if (chrome.windows) return;
+
   /** Inject interceptor script */
   const script = document.createElement('script');
   script.innerHTML = `

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -1,5 +1,3 @@
-import { getFrameInfoAsync } from './chat-utils.js';
-
 const isReplay = window.location.href.startsWith(
   'https://www.youtube.com/live_chat_replay'
 );
@@ -32,7 +30,6 @@ const chatLoaded = async () => {
   document.body.appendChild(script);
 
   /** Register interceptor */
-  const frameInfo = await getFrameInfoAsync();
   const port = chrome.runtime.connect();
   port.postMessage({ type: 'registerInterceptor' });
 
@@ -40,7 +37,6 @@ const chatLoaded = async () => {
   window.addEventListener('messageReceive', (d) => {
     port.postMessage({
       type: 'sendToClients',
-      frameInfo,
       response: d.detail,
       isReplay
     });
@@ -57,7 +53,6 @@ const chatLoaded = async () => {
     const json = text.replace(start, '').slice(0, -1);
     port.postMessage({
       type: 'setInitialData',
-      frameInfo,
       response: json,
       isReplay
     });
@@ -68,7 +63,6 @@ const chatLoaded = async () => {
     if (d.data['yt-player-video-progress'] != null) {
       port.postMessage({
         type: 'sendPlayerProgress',
-        frameInfo,
         playerProgress: d.data['yt-player-video-progress']
       });
     }

--- a/scripts/chat-interceptor.js
+++ b/scripts/chat-interceptor.js
@@ -25,7 +25,6 @@ const messageReceiveCallback = (response, isInitial = false) => {
   });
 };
 
-// FIXME: VOD chat does not work at the moment.
 const chatLoaded = () => {
   /** Inject interceptor script */
   const script = document.createElement('script');

--- a/scripts/chat-parser.js
+++ b/scripts/chat-parser.js
@@ -291,6 +291,7 @@ export const parseChatResponse = (response, isInitial = false) => {
     return;
   }
 
+  // TODO: We can probably remove one level of iteration here
   return {
     type: 'actionChunk',
     actions: parsedActions,

--- a/scripts/chat-parser.js
+++ b/scripts/chat-parser.js
@@ -173,10 +173,9 @@ const parsePinnedMessageAction = (action) => {
 };
 
 /**
- * Parse YTC JSON. Returns actionChunk payload.
- *
  * @param {YtcResponse} response JSON response.
  * @param {boolean} [isInitial=false] Whether JSON is initial data.
+ * @returns {*} actionChunk payload.
  */
 export const parseChatResponse = (response, isInitial = false) => {
   response = JSON.parse(response);

--- a/scripts/chat-parser.js
+++ b/scripts/chat-parser.js
@@ -247,8 +247,10 @@ const parseMessageDeletedAction = (action) => {
  */
 
 /**
- * @param {ytcResponse} response
- * @param {boolean} [isInitial=false]
+ * Parse YTC JSON. Returns actionChunk payload.
+ *
+ * @param {ytcResponse} response JSON response.
+ * @param {boolean} [isInitial=false] Whether JSON is initial data.
  */
 export const parseChatResponse = (response, isInitial = false) => {
   response = JSON.parse(response);

--- a/scripts/chat-parser.js
+++ b/scripts/chat-parser.js
@@ -111,6 +111,7 @@ const parseAddChatItemAction = (action) => {
       : date.getTime() - Math.round(timestampUsec / 1000),
     messageId: renderer.id
   };
+  // FIXME: Initial data is shown backwards
   // TODO: Super stickers
   if (actionItem.liveChatPaidMessageRenderer) {
     item.superchat = {

--- a/scripts/chat-parser.js
+++ b/scripts/chat-parser.js
@@ -85,9 +85,11 @@ const parseAddChatItemAction = (action, isReplay, offsetMs) => {
       const iconType = badgeRenderer.icon?.iconType;
       if (iconType) {
         authorTypes.push(iconType.toLowerCase());
-        return;
+      } else if (badgeRenderer.customThumbnail) {
+        authorTypes.push('member');
+      } else {
+        authorTypes.push(badgeRenderer.tooltip.toLowerCase());
       }
-      authorTypes.push(badgeRenderer.tooltip.toLowerCase());
     });
   }
   const runs = parseMessageRuns(renderer.message?.runs);

--- a/scripts/chat-utils.js
+++ b/scripts/chat-utils.js
@@ -4,3 +4,7 @@ export const getFrameInfoAsync = async () => {
       chrome.runtime.sendMessage({ type: 'getFrameInfo' }, resolve)
   );
 };
+
+export const createPopup = (url) => {
+  chrome.runtime.sendMessage({ type: 'createPopup', url });
+};

--- a/scripts/chat-utils.js
+++ b/scripts/chat-utils.js
@@ -1,0 +1,6 @@
+export const getFrameInfoAsync = async () => {
+  return new Promise(
+    (resolve, reject) =>
+      chrome.runtime.sendMessage({ type: 'getFrameInfo' }, resolve)
+  );
+};

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -1,6 +1,7 @@
 const isLiveTL = false;
 // DO NOT EDIT THE ABOVE LINE. It is updated by webpack.
 const getWAR = path => chrome.runtime.getURL(path);
+const isFirefox = navigator.userAgent.includes('Firefox');
 
 for (const eventName of ['visibilitychange', 'webkitvisibilitychange', 'blur']) {
   window.addEventListener(eventName, e => e.stopImmediatePropagation(), true);
@@ -399,7 +400,7 @@ const chatLoaded = async () => {
     elem.outerHTML = `
     <iframe id='optichat' src='${source}${(!window.isAndroid && isLiveTL ? '#isLiveTL' : '')}' style='border: 0px; width: 100%; height: 100%'></iframe>
     `;
-    if (window.isFirefox || window.isAndroid || isLiveTL) {
+    if (isFirefox || isLiveTL) {
       const frame = document.querySelector('#optichat');
       const scale = 0.8;
       const inverse = `${Math.round((1 / scale) * 10000) / 100}%`;

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -1,5 +1,7 @@
+import { getFrameInfoAsync } from './chat-utils.js';
+
 const isLiveTL = false;
-// DO NOT EDIT THE ABOVE LINE. It is updated by webpack.
+// DO NOT EDIT THE ABOVE LINE, it will be updated by webpack.
 const isFirefox = navigator.userAgent.includes('Firefox');
 
 const chatLoaded = () => {
@@ -421,18 +423,12 @@ const chatLoaded = () => {
   });
 
   // Note: iframe readyState is always 'complete' even when it shouldn't be
-  optichat.addEventListener('load', () => {
+  optichat.addEventListener('load', async () => {
     /** Forward frameInfo to optichat for background messaging */
-    const port = chrome.runtime.connect();
-    port.onMessage.addListener((message) => {
-      if (message.type === 'queryResult') {
-        optichat.contentWindow.postMessage(
-          { type: 'frameInfo', frameInfo: message.frameInfo }, '*'
-        );
-        port.disconnect();
-      }
-    });
-    port.postMessage({ type: 'queryFrameInfo' });
+    const frameInfo = await getFrameInfoAsync();
+    optichat.contentWindow.postMessage(
+      { type: 'frameInfo', frameInfo: frameInfo }, '*'
+    );
   });
 };
 

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -431,24 +431,22 @@ const chatLoaded = async () => {
     }
   });
 
-  // TODO: Initial data
-  // if (!hyperChatEnabled) {
-  //   return;
-  // }
-  // const processInitialJson = () => {
-  //   const scripts = document.querySelector('body').querySelectorAll('script');
-  //   scripts.forEach(script => {
-  //     const start = 'window["ytInitialData"] = ';
-  //     const text = script.text;
-  //     if (!text || !text.startsWith(start)) {
-  //       return;
-  //     }
-  //     const json = text.replace(start, '').slice(0, -1);
-  //     messageReceiveCallback(json, true);
-  //   });
-  // };
-  // const iframe = document.querySelector('#optichat');
-  // iframe.addEventListener('load', processInitialJson);
+  if (!hyperChatEnabled) {
+    return;
+  }
+
+  // eslint-disable-next-line no-undef
+  const port = chrome.runtime.connect();
+  port.onMessage.addListener((message) => {
+    if (message.type === 'queryResult') {
+      const frameInfo = message.frameInfo;
+      const iframe = document.querySelector('#optichat');
+      iframe.addEventListener('load', () => {
+        iframe.contentWindow.postMessage({ type: 'frameInfo', frameInfo }, '*');
+      });
+    }
+  });
+  port.postMessage({ type: 'queryFrameInfo' });
 };
 
 if (document.readyState === 'loading') {

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -2,6 +2,8 @@ import { getFrameInfoAsync } from './chat-utils.js';
 
 const isLiveTL = false;
 // DO NOT EDIT THE ABOVE LINE, it will be updated by webpack.
+const isAndroid = false;
+// DO NOT EDIT THE ABOVE LINE, it will be updated by webpack.
 const isFirefox = navigator.userAgent.includes('Firefox');
 
 const chatLoaded = () => {
@@ -392,7 +394,7 @@ const chatLoaded = () => {
   /** Inject optichat */
   const source = chrome.runtime.getURL(isLiveTL ? 'hyperchat/index.html' : 'index.html');
   ytcItemList.outerHTML = `
-  <iframe id='optichat' src='${source}${(!window.isAndroid && isLiveTL ? '#isLiveTL' : '')}' style='border: 0px; width: 100%; height: 100%'></iframe>
+  <iframe id='optichat' src='${source}${(!isAndroid && isLiveTL ? '#isLiveTL' : '')}' style='border: 0px; width: 100%; height: 100%'></iframe>
   `;
   if (isFirefox || isLiveTL) {
     const frame = document.querySelector('#optichat');

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -376,12 +376,12 @@ const chatLoaded = () => {
   // Everything beyond this is only run if HyperChat is enabled.
   if (!hyperChatEnabled) return;
 
-  window.postMessage({
-    'yt-player-video-progress': 0
-  }, '*');
-  window.postMessage({
-    'yt-player-video-progress': 69420
-  }, '*');
+  // window.postMessage({
+  //   'yt-player-video-progress': 0
+  // }, '*');
+  // window.postMessage({
+  //   'yt-player-video-progress': 69420
+  // }, '*');
 
   const ytcItemList = document.querySelector('#chat>#item-list');
   if (!ytcItemList) {
@@ -420,8 +420,6 @@ const chatLoaded = () => {
   window.addEventListener('message', d => {
     if (d.data.type === 'getTheme') {
       sendTheme();
-    } else if (d.data['yt-player-video-progress'] != null && optichat.contentWindow) {
-      optichat.contentWindow.postMessage(d.data, '*');
     }
   });
 

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -428,7 +428,7 @@ const chatLoaded = () => {
     /** Forward frameInfo to optichat for background messaging */
     const frameInfo = await getFrameInfoAsync();
     optichat.contentWindow.postMessage(
-      { type: 'frameInfo', frameInfo: frameInfo }, '*'
+      { type: 'frameInfo', frameInfo }, '*'
     );
   });
 };

--- a/scripts/chat.js
+++ b/scripts/chat.js
@@ -5,6 +5,9 @@ const isLiveTL = false;
 const isFirefox = navigator.userAgent.includes('Firefox');
 
 const chatLoaded = () => {
+  /** Workaround for https://github.com/LiveTL/HyperChat/issues/12 */
+  if (chrome.windows) return;
+
   if (document.querySelector('.toggleButton')) {
     console.debug('HC Button already injected.');
     return;

--- a/scripts/parse-chat.js
+++ b/scripts/parse-chat.js
@@ -1,0 +1,179 @@
+const isReplay = window.location.href.startsWith(
+  'https://www.youtube.com/live_chat_replay'
+);
+
+const formatTimestamp = (timestamp) => {
+  return (new Date(parseInt(timestamp) / 1000)).toLocaleTimeString(navigator.language,
+    { hour: '2-digit', minute: '2-digit' });
+};
+
+const getMillis = (timestamp, usec) => {
+  let secs = Array.from(timestamp.split(':'), t => parseInt(t)).reverse();
+  secs = secs[0] + (secs[1] ? secs[1] * 60 : 0) + (secs[2] ? secs[2] * 60 * 60 : 0);
+  secs *= 1000;
+  secs += usec % 1000;
+  secs /= 1000;
+  return secs;
+};
+
+const colorConversionTable = {
+  4280191205: 'blue',
+  4278248959: 'lightblue',
+  4280150454: 'turquoise',
+  4294953512: 'yellow',
+  4294278144: 'orange',
+  4293467747: 'pink',
+  4293271831: 'red'
+};
+
+const parseMessageRuns = (runs) => {
+  const parsedRuns = [];
+  runs.forEach((run) => {
+    if (run.text && run.navigationEndpoint) {
+      let url = run.navigationEndpoint.commandMetadata.webCommandMetadata.url;
+      if (url.startsWith('/')) {
+        url = 'https://www.youtube.com'.concat(url);
+      }
+      parsedRuns.push({
+        type: 'link',
+        text: decodeURIComponent(escape(unescape(encodeURIComponent(
+          run.text
+        )))),
+        url: url
+      });
+    } else if (run.text) {
+      parsedRuns.push({
+        type: 'text',
+        text: decodeURIComponent(escape(unescape(encodeURIComponent(
+          run.text
+        ))))
+      });
+    } else if (run.emoji) {
+      parsedRuns.push({
+        type: 'emote',
+        src: run.emoji.image.thumbnails[0].url
+      });
+    }
+  });
+  return parsedRuns;
+};
+
+const parseAddChatItemAction = (action) => {
+  console.log(action);
+  const actionItem = action.item;
+  if (!actionItem) {
+    return false;
+  }
+  const renderer = actionItem.liveChatTextMessageRenderer ||
+    actionItem.liveChatPaidMessageRenderer ||
+    actionItem.liveChatPaidStickerRenderer;
+  if (!renderer || !renderer.authorName || !renderer.message) { // FIXME: Doesn't allow empty superchats
+    return false;
+  }
+
+  const authorTypes = [];
+  if (renderer.authorBadges) {
+    renderer.authorBadges.forEach((badge) =>
+      authorTypes.push(badge.liveChatAuthorBadgeRenderer.tooltip.toLowerCase())
+    );
+  }
+  const runs = parseMessageRuns(renderer.message.runs);
+  const timestampUsec = parseInt(renderer.timestampUsec);
+  const timestampText = renderer.timestampText?.simpleText; // only used on replays
+  const date = new Date();
+  const item = {
+    author: {
+      name: renderer.authorName.simpleText,
+      id: renderer.authorExternalChannelId,
+      types: authorTypes
+    },
+    message: runs,
+    timestamp: isReplay ? timestampText : formatTimestamp(timestampUsec),
+    showtime: isReplay ? getMillis(timestampText, timestampUsec)
+      : date.getTime() - Math.round(timestampUsec / 1000),
+    messageId: renderer.id
+  };
+  if (actionItem.liveChatPaidMessageRenderer) {
+    item.superchat = {
+      amount: renderer.purchaseAmountText.simpleText,
+      color: colorConversionTable[renderer.bodyBackgroundColor]
+    };
+  }
+  return {
+    type: 'addChatItem',
+    item: item
+  };
+};
+
+const parseAuthorBonkedAction = (action) => {
+  if (!action.deletedStateMessage || !action.externalChannelId) {
+    return false;
+  }
+  return {
+    type: 'authorBonked',
+    item: {
+      replacedMessage: parseMessageRuns(action.deletedStateMessage.runs),
+      authorId: action.externalChannelId
+    }
+  };
+};
+
+const parseMessageDeletedAction = (action) => {
+  if (!action.deletedStateMessage || !action.targetItemId) {
+    return false;
+  }
+  return {
+    type: 'messageDeleted',
+    item: {
+      replacedMessage: parseMessageRuns(action.deletedStateMessage.runs),
+      messageId: action.targetItemId
+    }
+  };
+};
+
+export const parseChatResponse = (response, isInitial = false) => {
+  response = JSON.parse(response);
+  const parsedActions = [];
+  const actionsArray =
+    response.continuationContents?.liveChatContinuation?.actions ||
+    response.contents?.liveChatRenderer?.actions;
+  if (!actionsArray) {
+    console.debug('Invalid response:', response);
+    return;
+  }
+
+  actionsArray.forEach((action) => {
+    let parsedAction;
+    if (action.addChatItemAction) {
+      parsedAction = parseAddChatItemAction(action.addChatItemAction);
+    } else if (action.replayChatItemAction?.actions[0]?.addChatItemAction) {
+      parsedAction = parseAddChatItemAction(
+        action.replayChatItemAction.actions[0].addChatItemAction
+      );
+    } else if (action.markChatItemsByAuthorAsDeletedAction) {
+      parsedAction = parseAuthorBonkedAction(
+        action.markChatItemsByAuthorAsDeletedAction
+      );
+    } else if (action.markChatItemAsDeletedAction) {
+      parsedAction = parseMessageDeletedAction(
+        action.markChatItemAsDeletedAction
+      );
+    }
+
+    if (!parsedAction) {
+      console.debug('Unparsed action:', action);
+      return;
+    }
+    parsedActions.push(parsedAction);
+  });
+  if (parsedActions.length < 1) {
+    return;
+  }
+
+  return {
+    type: 'actionChunk',
+    actions: parsedActions,
+    isReplay,
+    isInitial
+  };
+};

--- a/scripts/parse-chat.js
+++ b/scripts/parse-chat.js
@@ -59,7 +59,7 @@ const parseMessageRuns = (runs) => {
 };
 
 const parseAddChatItemAction = (action) => {
-  console.log(action);
+  // console.log(action);
   const actionItem = action.item;
   if (!actionItem) {
     return false;

--- a/scripts/types.js
+++ b/scripts/types.js
@@ -1,0 +1,109 @@
+/** Base JSON */
+/**
+ * Expected YTC JSON response.
+ *
+ * @typedef {Object} YtcResponse
+ * @property {Object} [continuationContents]
+ * @property {Object} continuationContents.liveChatContinuation
+ * @property {YtcAction[]} [continuationContents.liveChatContinuation.actions]
+ *
+ * @property {Object} [contents]
+ * @property {Object} contents.liveChatRenderer
+ * @property {YtcAction[]} [contents.liveChatRenderer.actions]
+ */
+/**
+ * Expected YTC action object.
+ *
+ * @typedef {Object} YtcAction
+ * @property {AddChatItemAction} [addChatItemAction]
+ * @property {{actions: ytcAction[]}} [replayChatItemAction]
+ * @property {AuthorBonkedAction} [markChatItemsByAuthorAsDeletedAction]
+ * @property {MessageDeletedAction} [markChatItemAsDeletedAction]
+ * @property {AddPinnedAction} [addBannerToLiveChatCommand]
+ * @property {*} [removeBannerForLiveChatCommand]
+ */
+
+/** Actions */
+/**
+ * YTC addChatItemAction object.
+ *
+ * @typedef {Object} AddChatItemAction
+ * @property {Object} item
+ * @property {MessageRenderer} [item.liveChatTextMessageRenderer]
+ * @property {MessageRenderer} [item.liveChatPaidMessageRenderer]
+ * @property {MessageRenderer} [item.liveChatPaidStickerRenderer]
+ */
+/**
+ * YTC markChatItemsByAuthorAsDeletedAction object.
+ *
+ * @typedef {Object} AuthorBonkedAction
+ * @property {Object} deletedStateMessage Message to replace deleted messages.
+ * @property {MessageRun[]} deletedStateMessage.runs
+ * @property {string} externalChannelId ID of channel that was bonked.
+ */
+/**
+ * YTC markChatItemAsDeletedAction object.
+ *
+ * @typedef {Object} MessageDeletedAction
+ * @property {Object} deletedStateMessage Message to replace deleted messages.
+ * @property {MessageRun[]} deletedStateMessage.runs
+ * @property {string} targetItemId ID of message to be deleted.
+ */
+/**
+ * YTC addBannerToLiveChatCommand object.
+ *
+ * @typedef {Object} AddPinnedAction
+ * @property {Object} bannerRenderer
+ * @property {Object} bannerRenderer.liveChatBannerRenderer
+ * @property {MessageRenderer} bannerRenderer.liveChatBannerRenderer.contents
+ * @property {BannerHeader} bannerRenderer.liveChatBannerRenderer.header
+ */
+
+/** Misc types */
+/**
+ * YTC message run object.
+ *
+ * @typedef {Object} MessageRun
+ * @property {string} [text]
+ *
+ * @property {Object} [navigationEndpoint]
+ * @property {Object} navigationEndpoint.commandMetadata
+ * @property {Object} navigationEndpoint.commandMetadata.webCommandMetadata
+ * @property {string} navigationEndpoint.commandMetadata.webCommandMetadata.url
+ *
+ * @property {Object} [emoji]
+ * @property {Object} emoji.image
+ * @property {{url: string}[]} emoji.image.thumbnails
+ */
+/**
+ * YTC message renderer object.
+ *
+ * @typedef {Object} MessageRenderer
+ * @property {Object} message
+ * @property {MessageRun[]} message.runs
+ * @property {{simpleText: string}} authorName
+ * @property {AuthorBadge[]} [authorBadges]
+ * @property {string} id
+ * @property {string} timestampUsec Timestamp in microseconds
+ * @property {string} authorExternalChannelId
+ * @property {{simpleText: string}} [timestampText] Only available on VODs
+ * @property {{simpleText: string}} [purchaseAmountText] Only available on superchats
+ * @property {number} [bodyBackgroundColor] Only available on superchats
+ */
+/**
+ * YTC author badge object.
+ *
+ * @typedef {Object} AuthorBadge
+ * @property {Object} liveChatAuthorBadgeRenderer
+ * @property {string} liveChatAuthorBadgeRenderer.tooltip
+ * @property {Object} [liveChatAuthorBadgeRenderer.icon] Only available for verified, mods and owner
+ * @property {string} liveChatAuthorBadgeRenderer.icon.iconType Unlocalized string
+ */
+/**
+ * YTC banner header object.
+ *
+ * @typedef {Object} BannerHeader
+ * @property {Object} liveChatBannerHeaderRenderer
+ * @property {Object} liveChatBannerHeaderRenderer.text
+ * @property {MessageRun[]} liveChatBannerHeaderRenderer.text.runs
+ */

--- a/scripts/types.js
+++ b/scripts/types.js
@@ -98,6 +98,7 @@
  * YTC author badge object.
  * @typedef {Object} AuthorBadge
  * @property {Object} liveChatAuthorBadgeRenderer
+ * @property {*} liveChatAuthorBadgeRenderer.customThumbnail
  * @property {string} liveChatAuthorBadgeRenderer.tooltip
  * @property {Object} [liveChatAuthorBadgeRenderer.icon] Only available for verified, mods and owner
  * @property {string} liveChatAuthorBadgeRenderer.icon.iconType Unlocalized string

--- a/scripts/types.js
+++ b/scripts/types.js
@@ -4,16 +4,26 @@
  * @typedef {Object} YtcResponse
  * @property {Object} [continuationContents]
  * @property {Object} continuationContents.liveChatContinuation
+ * @property {ContinuationData[]} continuationContents.liveChatContinuation.continuations
  * @property {YtcAction[]} [continuationContents.liveChatContinuation.actions]
- * @property {Object} [contents]
+ * @property {Object} [contents] Initial data only
  * @property {Object} contents.liveChatRenderer
+ * @property {ContinuationData[]} contents.liveChatRenderer.continuations
  * @property {YtcAction[]} [contents.liveChatRenderer.actions]
+ */
+/**
+ * Expected YTC continuation data object
+ * @typedef {Object} ContinuationData
+ * @property {Object} [timedContinuationData]
+ * @property {number} timedContinuationData.timeoutMs
+ * @property {Object} [invalidationContinuationData]
+ * @property {number} invalidationContinuationData.timeoutMs
  */
 /**
  * Expected YTC action object.
  * @typedef {Object} YtcAction
  * @property {AddChatItemAction} [addChatItemAction]
- * @property {{actions: ytcAction[]}} [replayChatItemAction]
+ * @property {ReplayChatItemAction} [replayChatItemAction]
  * @property {AuthorBonkedAction} [markChatItemsByAuthorAsDeletedAction]
  * @property {MessageDeletedAction} [markChatItemAsDeletedAction]
  * @property {AddPinnedAction} [addBannerToLiveChatCommand]
@@ -28,6 +38,11 @@
  * @property {MessageRenderer} [item.liveChatTextMessageRenderer]
  * @property {MessageRenderer} [item.liveChatPaidMessageRenderer]
  * @property {MessageRenderer} [item.liveChatPaidStickerRenderer]
+ */
+/**
+ * @typedef {Object} ReplayChatItemAction
+ * @property {ytcAction[]} actions
+ * @property {IntString} videoOffsetTimeMsec
  */
 /**
  * YTC markChatItemsByAuthorAsDeletedAction object.
@@ -73,7 +88,7 @@
  * @property {{simpleText: string}} authorName
  * @property {AuthorBadge[]} [authorBadges]
  * @property {string} id
- * @property {string} timestampUsec Timestamp in microseconds
+ * @property {IntString} timestampUsec Timestamp in microseconds
  * @property {string} authorExternalChannelId
  * @property {{simpleText: string}} [timestampText] Only available on VODs
  * @property {{simpleText: string}} [purchaseAmountText] Only available on superchats
@@ -94,3 +109,4 @@
  * @property {Object} liveChatBannerHeaderRenderer.text
  * @property {MessageRun[]} liveChatBannerHeaderRenderer.text.runs
  */
+/** @typedef {string} IntString Integer formatted as string */

--- a/scripts/types.js
+++ b/scripts/types.js
@@ -1,19 +1,16 @@
 /** Base JSON */
 /**
  * Expected YTC JSON response.
- *
  * @typedef {Object} YtcResponse
  * @property {Object} [continuationContents]
  * @property {Object} continuationContents.liveChatContinuation
  * @property {YtcAction[]} [continuationContents.liveChatContinuation.actions]
- *
  * @property {Object} [contents]
  * @property {Object} contents.liveChatRenderer
  * @property {YtcAction[]} [contents.liveChatRenderer.actions]
  */
 /**
  * Expected YTC action object.
- *
  * @typedef {Object} YtcAction
  * @property {AddChatItemAction} [addChatItemAction]
  * @property {{actions: ytcAction[]}} [replayChatItemAction]
@@ -26,7 +23,6 @@
 /** Actions */
 /**
  * YTC addChatItemAction object.
- *
  * @typedef {Object} AddChatItemAction
  * @property {Object} item
  * @property {MessageRenderer} [item.liveChatTextMessageRenderer]
@@ -35,7 +31,6 @@
  */
 /**
  * YTC markChatItemsByAuthorAsDeletedAction object.
- *
  * @typedef {Object} AuthorBonkedAction
  * @property {Object} deletedStateMessage Message to replace deleted messages.
  * @property {MessageRun[]} deletedStateMessage.runs
@@ -43,7 +38,6 @@
  */
 /**
  * YTC markChatItemAsDeletedAction object.
- *
  * @typedef {Object} MessageDeletedAction
  * @property {Object} deletedStateMessage Message to replace deleted messages.
  * @property {MessageRun[]} deletedStateMessage.runs
@@ -51,7 +45,6 @@
  */
 /**
  * YTC addBannerToLiveChatCommand object.
- *
  * @typedef {Object} AddPinnedAction
  * @property {Object} bannerRenderer
  * @property {Object} bannerRenderer.liveChatBannerRenderer
@@ -62,22 +55,18 @@
 /** Misc types */
 /**
  * YTC message run object.
- *
  * @typedef {Object} MessageRun
  * @property {string} [text]
- *
  * @property {Object} [navigationEndpoint]
  * @property {Object} navigationEndpoint.commandMetadata
  * @property {Object} navigationEndpoint.commandMetadata.webCommandMetadata
  * @property {string} navigationEndpoint.commandMetadata.webCommandMetadata.url
- *
  * @property {Object} [emoji]
  * @property {Object} emoji.image
  * @property {{url: string}[]} emoji.image.thumbnails
  */
 /**
  * YTC message renderer object.
- *
  * @typedef {Object} MessageRenderer
  * @property {Object} message
  * @property {MessageRun[]} message.runs
@@ -92,7 +81,6 @@
  */
 /**
  * YTC author badge object.
- *
  * @typedef {Object} AuthorBadge
  * @property {Object} liveChatAuthorBadgeRenderer
  * @property {string} liveChatAuthorBadgeRenderer.tooltip
@@ -101,7 +89,6 @@
  */
 /**
  * YTC banner header object.
- *
  * @typedef {Object} BannerHeader
  * @property {Object} liveChatBannerHeaderRenderer
  * @property {Object} liveChatBannerHeaderRenderer.text

--- a/src/App.vue
+++ b/src/App.vue
@@ -198,6 +198,7 @@ export default {
         runQueue();
         runQueue();
       }
+      /** Separate each action */
       const messages = [];
       const bonks = [];
       const deletions = [];
@@ -210,17 +211,19 @@ export default {
           deletions.push(action.item);
         }
       });
+      /** Sort and add messages to queue */
       for (const message of messages.sort(
         (m1, m2) => m1.showtime - m2.showtime
       )) {
         let timestamp = (Date.now() + message.showtime) / 1000;
-        if (message.isReplay || message.isInitial) timestamp = message.showtime;
+        if (payload.isReplay || payload.isInitial) timestamp = message.showtime;
         this.checkDeleted(message, bonks, deletions);
         this.queued.push({
           timestamp,
           message: message
         });
       }
+      /** Handle deletions and bonks */
       if (!bonks.length && !deletions.length) {
         return;
       }
@@ -235,6 +238,7 @@ export default {
 
     window.addEventListener('message', async (message) => {
       const data = message.data;
+      /** Connect to background messaging as client */
       if (data.type === 'frameInfo') {
         const port = chrome.runtime.connect();
         port.postMessage({ type: 'registerClient', frameInfo: data.frameInfo });
@@ -242,7 +246,7 @@ export default {
           processMessagePayload(payload);
         });
       }
-
+      /** Handle YT values */
       const d = JSON.parse(JSON.stringify(data));
       this.isAtBottom = this.checkIfBottom();
       if (d['yt-player-video-progress'] && !this.interval) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -184,62 +184,63 @@ export default {
       this.scrollToBottom();
     });
 
+    const processMessagePayload = (payload) => {
+      if (payload.type !== 'actionChunk') {
+        return;
+      }
+      if (!payload.isReplay && !this.interval) {
+        const runQueue = () => {
+          this.videoProgressUpdated({
+            'yt-player-video-progress': Date.now() / 1000
+          });
+        };
+        this.interval = setInterval(runQueue, 250);
+        runQueue();
+        runQueue();
+      }
+      const messages = [];
+      const bonks = [];
+      const deletions = [];
+      payload.actions.forEach((action) => {
+        if (action.type === 'addChatItem') {
+          messages.push(action.item);
+        } else if (action.type === 'authorBonked') {
+          bonks.push(action.item);
+        } else if (action.type === 'messageDeleted') {
+          deletions.push(action.item);
+        }
+      });
+      for (const message of messages.sort(
+        (m1, m2) => m1.showtime - m2.showtime
+      )) {
+        let timestamp = (Date.now() + message.showtime) / 1000;
+        if (message.isReplay || message.isInitial) timestamp = message.showtime;
+        this.checkDeleted(message, bonks, deletions);
+        this.queued.push({
+          timestamp,
+          message: message
+        });
+      }
+      if (!bonks.length && !deletions.length) {
+        return;
+      }
+      const wasBottom = this.checkIfBottom();
+      this.messages.forEach((message) =>
+        this.checkDeleted(message, bonks, deletions)
+      );
+      if (wasBottom) {
+        this.$nextTick(this.scrollToBottom);
+      }
+    };
+
     window.addEventListener('message', async (message) => {
       const data = message.data;
       if (data.type === 'frameInfo') {
-        // eslint-disable-next-line no-undef
         const port = chrome.runtime.connect();
         port.postMessage({ type: 'registerClient', frameInfo: data.frameInfo });
         port.onMessage.addListener((payload) => {
-          if (payload.type !== 'actionChunk') {
-            return;
-          }
-          if (!payload.isReplay && !this.interval) {
-            const runQueue = () => {
-              this.videoProgressUpdated({
-                'yt-player-video-progress': Date.now() / 1000
-              });
-            };
-            this.interval = setInterval(runQueue, 250);
-            runQueue();
-            runQueue();
-          }
-          const messages = [];
-          const bonks = [];
-          const deletions = [];
-          payload.actions.forEach((action) => {
-            if (action.type === 'addChatItem') {
-              messages.push(action.item);
-            } else if (action.type === 'authorBonked') {
-              bonks.push(action.item);
-            } else if (action.type === 'messageDeleted') {
-              deletions.push(action.item);
-            }
-          });
-          for (const message of messages.sort(
-            (m1, m2) => m1.showtime - m2.showtime
-          )) {
-            let timestamp = (Date.now() + message.showtime) / 1000;
-            if (message.isReplay || message.isInitial) timestamp = message.showtime;
-            this.checkDeleted(message, bonks, deletions);
-            this.queued.push({
-              timestamp,
-              message: message
-            });
-          }
-          if (!bonks.length && !deletions.length) {
-            return;
-          }
-          const wasBottom = this.checkIfBottom();
-          this.messages.forEach((message) =>
-            this.checkDeleted(message, bonks, deletions)
-          );
-          if (wasBottom) {
-            this.$nextTick(this.scrollToBottom);
-          }
+          processMessagePayload(payload);
         });
-
-        return;
       }
 
       const d = JSON.parse(JSON.stringify(data));

--- a/src/App.vue
+++ b/src/App.vue
@@ -214,11 +214,9 @@ export default {
       for (const message of messages.sort(
         (m1, m2) => m1.showtime - m2.showtime
       )) {
-        let timestamp = (Date.now() + message.showtime) / 1000;
-        if (payload.isReplay || payload.isInitial) timestamp = message.showtime;
         this.checkDeleted(message, bonks, deletions);
         this.queued.push({
-          timestamp,
+          timestamp: message.showtime / 1000,
           message: message
         });
       }

--- a/src/App.vue
+++ b/src/App.vue
@@ -343,6 +343,7 @@ export default {
       }
     },
     checkDeleted(message, bonks, deletions) {
+      if (message.welcomeMessage) return;
       for (const bonk of bonks) {
         if (bonk.authorId === message.author.id) {
           message.message = bonk.replacedMessage;

--- a/src/App.vue
+++ b/src/App.vue
@@ -183,15 +183,14 @@ export default {
       // await this.$forceUpdate();
       this.scrollToBottom();
     });
-    window.addEventListener('message', async (d) => {
-      d = JSON.parse(JSON.stringify(d.data));
-      this.isAtBottom = this.checkIfBottom();
-      if (d['yt-player-video-progress'] && !this.interval) {
-        this.videoProgressUpdated(d);
-      } else if (d['yt-live-chat-set-dark-theme'] != null) {
-        this.$vuetify.theme.dark = d['yt-live-chat-set-dark-theme'];
-        localStorage.setItem('dark_theme', this.$vuetify.theme.dark.toString());
-      } else if (d.type === 'actionChunk') {
+    // eslint-disable-next-line no-undef
+    chrome.tabs.getCurrent((tab) => {
+      // eslint-disable-next-line no-undef
+      const port = chrome.tabs.connect(tab.id);
+      port.onMessage.addListener((d) => {
+        if (d.type !== 'actionChunk') {
+          return;
+        }
         if (!d.isReplay && !this.interval) {
           const runQueue = () => {
             this.videoProgressUpdated({
@@ -235,6 +234,17 @@ export default {
         if (wasBottom) {
           this.$nextTick(this.scrollToBottom);
         }
+      });
+    });
+
+    window.addEventListener('message', async (d) => {
+      d = JSON.parse(JSON.stringify(d.data));
+      this.isAtBottom = this.checkIfBottom();
+      if (d['yt-player-video-progress'] && !this.interval) {
+        this.videoProgressUpdated(d);
+      } else if (d['yt-live-chat-set-dark-theme'] != null) {
+        this.$vuetify.theme.dark = d['yt-live-chat-set-dark-theme'];
+        localStorage.setItem('dark_theme', this.$vuetify.theme.dark.toString());
       }
     });
     window.parent.postMessage(

--- a/src/App.vue
+++ b/src/App.vue
@@ -207,18 +207,9 @@ export default {
         runQueue();
       }
       /** Separate each action */
-      const messages = [];
-      const bonks = [];
-      const deletions = [];
-      payload.actions.forEach((action) => {
-        if (action.type === 'addChatItem') {
-          messages.push(action.item);
-        } else if (action.type === 'authorBonked') {
-          bonks.push(action.item);
-        } else if (action.type === 'messageDeleted') {
-          deletions.push(action.item);
-        }
-      });
+      const messages = payload.messages;
+      const bonks = payload.bonks;
+      const deletions = payload.deletions;
       /** Sort and add messages to queue */
       for (const message of messages.sort(
         (m1, m2) => m1.showtime - m2.showtime

--- a/src/App.vue
+++ b/src/App.vue
@@ -241,7 +241,11 @@ export default {
       /** Connect to background messaging as client */
       if (data.type === 'frameInfo') {
         const port = chrome.runtime.connect();
-        port.postMessage({ type: 'registerClient', frameInfo: data.frameInfo });
+        port.postMessage({
+          type: 'registerClient',
+          frameInfo: data.frameInfo,
+          getInitialData: true
+        });
         port.onMessage.addListener((payload) => {
           processMessagePayload(payload);
         });


### PR DESCRIPTION
This PR is a massive refactor of the YTC interception process. The main purpose of this refactor is to centralize YTC interception and parsing, rather than having HC and LTL do it on their own separate scripts.

This refactor relies on [runtime.Port](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/Port) for communcation between the interceptor script and any "client" scripts (such as HC or LTL), with `chat-background.js` as the middleman. This greatly streamlines the messaging process, instead of juggling between `window.postMessage`, `runtime.sendMessage` and `tabs.sendMessage` that LiveTL currently does.

Some other fixes/changes included in the refactor:

- Fixed `showtime`, messages now actually appear at correct times for both live chat and chat replay.
- Added JSON parsing for pinned message action and remove pinned message action. UI is still not implemented though.
- Streamlined `actionChunk`, with common actions such as `messages`, `bonks` and `deletions` being properties to remove a level of iteration. Rarely used actions (such as pinned message) will be in the `miscActions` property.
- Usage of unlocalized author types via `liveChatAuthorBadgeRenderer.icon.iconType` whenever available, which is currently only for owner, mods and verified. We would still need to implement something like i18n to handle member badges on different YT languages.
- Workaround for LiveTL/HyperChat#12 included.

Both LiveTL and standalone HyperChat would need their respective PRs of the same name merged and their submodules updated for this to work.

P.S.: I've done my best to test on both FF and Chromium, using all modes on live streams and VODs, as well as on Holodex multiview, but please get the beta testers to test these updates if it is merged before pushing to public lol.