### PR TITLE
Use en-GB timestamp string

### DIFF
--- a/scripts/chat-parser.js
+++ b/scripts/chat-parser.js
@@ -1,8 +1,9 @@
-const formatTimestamp = (timestamp) => {
-  return (new Date(parseInt(timestamp) / 1000))
-    .toLocaleTimeString(
-      navigator.language, { hour: '2-digit', minute: '2-digit' }
-    );
+/**
+ * @param {number} timestampUsec 
+ */
+const formatTimestamp = (timestampUsec) => {
+  return (new Date(timestampUsec / 1000))
+    .toLocaleTimeString('en-GB');
 };
 
 const colorConversionTable = {


### PR DESCRIPTION
Previously, the timestamp string was formatted based on the user's browser/OS language, which causes problems when trying to compare them with timestamp strings on another format.

This PR changes it to always use the `en-GB` locale, which will always produce timestamp strings in `hh:mm:ss` format.

By the way the previous format was always in variants of `hh:mm` which was already questionable when comparing timestamp strings lmao.

Fixes LiveTL/LiveTL#282.